### PR TITLE
Remove resetrecycle tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,22 @@ matrix:
     - env: TOXENV=py36-djmaster
     - env: TOXENV=py37-djmaster
   include:
+    - python: 3.4
+      env: TOXENV=py34-dj18
+    - python: 3.4
+      env: TOXENV=py34-dj19
+    - python: 3.4
+      env: TOXENV=py34-dj110
+    - python: 3.4
+      env: TOXENV=py34-dj111
+    - python: 3.4
+      env: TOXENV=py34-dj20
+    - python: 3.5
+      env: TOXENV=py35-dj18
+    - python: 3.5
+      env: TOXENV=py35-dj19
+    - python: 3.5
+      env: TOXENV=py35-dj110
     - python: 3.5
       env: TOXENV=py35-dj111
     - python: 3.5

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -7,6 +7,9 @@ Changelog
 
 * Added description to ``setup.py``
 
+* Added support from Django 1.8, 1.9 and 1.10. Now supporting 1.8 - 1.11 (and
+  2.0 preliminary)
+
 0.2.0
 =====
 

--- a/example/example/urls.py
+++ b/example/example/urls.py
@@ -16,7 +16,7 @@ Including another URLconf
 import django
 from django.contrib import admin
 
-if django.VERSION >= (2, 0):
+if django.VERSION[:2] >= (2, 0):
     from django.urls import include, path
     urlpatterns = [
         path('admin/postgres-metrics/', include('postgres_metrics.urls')),

--- a/postgres_metrics/templates/postgres_metrics/table.html
+++ b/postgres_metrics/templates/postgres_metrics/table.html
@@ -45,7 +45,6 @@
                     {% for row in result.records %}
                     <tr class="{% cycle 'row1' 'row2' %}">{% for item in row %}<td>{{ item }}</td>{% endfor %}</tr>
                     {% endfor %}
-                    {% resetcycle %}
                 </tbody>
             </table>
         </div>

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,10 @@ setup(
     license='BSD',
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     include_package_data=True,
-    install_requires=['Django>=1.11', 'psycopg2'],
+    install_requires=[
+        'Django>=1.8',
+        'psycopg2',
+    ],
     zip_safe=False,
     classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -12,6 +12,8 @@ https://docs.djangoproject.com/en/dev/ref/settings/
 
 import os
 
+import django
+
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -72,15 +74,17 @@ WSGI_APPLICATION = 'wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/dev/ref/settings/#databases
 
+pg_engine = 'postgresql_psycopg2' if django.VERSION[:2] <= (1, 8) else 'postgresql'
+
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.postgresql',
+        'ENGINE': 'django.db.backends.%s' % pg_engine,
         'NAME': 'somedb',
         'USER': 'someuser',
         'PASSWORD': 'somepass',
     },
     'second': {
-        'ENGINE': 'django.db.backends.postgresql',
+        'ENGINE': 'django.db.backends.%s' % pg_engine,
         'NAME': 'otherdb',
         'USER': 'otheruser',
     },

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist =
-	py{35}-dj{111,20,master},
+	py{34}-dj{18,19,110,111,20},
+	py{35}-dj{18,19,110,111,20,master},
 	py{36,37}-dj{20,master},
 	flake8,
 	isort
@@ -10,6 +11,9 @@ skipsdist = True
 setenv =
 	PYTHONDONTWRITEBYTECODE=1
 deps =
+	dj18: Django>=1.8,<1.9
+	dj19: Django>=1.9,<=1.10
+	dj110: Django>=1.10,<1.11
 	dj111: Django>=1.11,<2.0
 	dj20: Django<2.1
 	djmaster: https://github.com/django/django/archive/master.tar.gz


### PR DESCRIPTION
The only thing preventing the app from working with django 1.10 is the
resetcycle tag, which was introduced in 1.11. There doesn't appear to be
an obvious backport of this tag, so I'm offering to just remove it.

See #13