### PR TITLE
Switch to Django-defined colors for dark mode support

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,7 +2,9 @@ django-postgres-metrics was originally created in 2017 by Markus Holtermann.
 
 Here is an inevitably incomplete list of MUCH-APPRECIATED CONTRIBUTORS --
 people who have submitted patches, reported bugs, added translations, helped
-answer newbie questions, and generally made Django that much better:
+answer newbie questions, and generally made django-postgres-metrics that much
+better:
 
     Markus Holtermann <https://markusholtermann.eu>
     Dusty Phillips <dusty@buchuki.com>
+    Thibaud Colas <https://github.com/thibaudcolas>

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -7,6 +7,12 @@ Changelog
 Under Development
 =================
 
+* Added dark-mode support. (`PR #59
+  <https://github.com/django-postgres-metrics/django-postgres-metrics/pull/59>`_)
+
+* Fixed several accessibility issues. (`PR #58
+  <https://github.com/django-postgres-metrics/django-postgres-metrics/pull/58>`_)
+
 0.10.1 (2021-04-06)
 ===================
 

--- a/post_screenshot_comment.py
+++ b/post_screenshot_comment.py
@@ -90,6 +90,7 @@ if __name__ == "__main__":
     comment_id = find_screenshot_comment_id(pr_id)
     images = get_image_urls(sys.argv[2])
     body = format_body(images)
+    print(body)
     token = os.environ["GITHUB_TOKEN"]
     if comment_id:
         update_comment(comment_id, body, token)

--- a/postgres_metrics/static/postgres_metrics/css/base.css
+++ b/postgres_metrics/static/postgres_metrics/css/base.css
@@ -26,20 +26,20 @@
 
 tr.pgm-critical,
 td.pgm-critical {
-  background-color: #ffefef;
+  background-color: var(--message-error-bg);
 }
 
 tr.pgm-warning,
 td.pgm-warning {
-  background-color: #ffffcc;
+  background-color: var(--message-warning-bg);
 }
 
 tr.pgm-ok,
 td.pgm-ok {
-  background-color: #ddffdd;
+  background-color: var(--message-success-bg);
 }
 
 tr.pgm-info,
 td.pgm-info {
-  background-color: #9adeff;
+  background-color: var(--breadcrumbs-bg);
 }


### PR DESCRIPTION
See #57 – in particular the dark mode support problem:

<img width="912" alt="Screenshot of four highlighted rows in Django Postgres Metrics in dark mode. The rows aren’t readable" src="https://user-images.githubusercontent.com/877585/120897256-109ce100-c61d-11eb-8357-3cacfaa31b2d.png">

This PR addresses this by switching to Django’s custom properties, which will automagically switch to variants that are compatible with dark mode. I’ve kept the previous values as fallbacks, for backwards compatibility with older versions of Django. Note this syntax doesn’t work in IE11 – if you think that’s an issue, we can also add a fallback for that.

Here is the result:

![Recording of the same four rows as above, switching between light and dark mode](https://user-images.githubusercontent.com/877585/120898131-7ab78500-c621-11eb-8287-9e60f60ae79e.gif)

I believe the first 3 colors are the same as before. The last one is a bit of a hack, as I don’t think Django has a "highlight" color, but their breadcrumb color is intended to work well with both light and dark text.