### PR TITLE
Add missing fallback for CSS custom properties for highlight colors

### DIFF
--- a/postgres_metrics/static/postgres_metrics/css/base.css
+++ b/postgres_metrics/static/postgres_metrics/css/base.css
@@ -26,20 +26,20 @@
 
 tr.pgm-critical,
 td.pgm-critical {
-  background-color: var(--message-error-bg);
+  background-color: var(--message-error-bg, #ffefef);
 }
 
 tr.pgm-warning,
 td.pgm-warning {
-  background-color: var(--message-warning-bg);
+  background-color: var(--message-warning-bg, #ffffcc);
 }
 
 tr.pgm-ok,
 td.pgm-ok {
-  background-color: var(--message-success-bg);
+  background-color: var(--message-success-bg, #ddffdd);
 }
 
 tr.pgm-info,
 td.pgm-info {
-  background-color: var(--breadcrumbs-bg);
+  background-color: var(--breadcrumbs-bg, #9adeff);
 }


### PR DESCRIPTION
Sorry, I thought I had added the fallback colors in #59, but that commit somehow hadn’t made it to that branch 🤦 .

Django’s CSS variables for colors have only been introduced as part of the dark mode support for Django 3.2, so having those fallback values is important for backwards compatibility with older releases. The values are identical to the ones defined prior switching to CSS variables, except for `info`, which uses the breadcrumb blue.