### PR TITLE
Remove upper version bound on django-rich

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setuptools.setup(
     ),
     include_package_data=True,
     install_requires=[
-        "django-rich>=1.0,<2.0",
+        "django-rich>=1.0",
     ],
     extras_require={
         "dev": ["pre-commit"],


### PR DESCRIPTION
As per https://github.com/django-postgres-metrics/django-postgres-metrics/pull/69#discussion_r835935127